### PR TITLE
fix to register the plugin using rejoice

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,4 +70,6 @@ exports.register = function (server, options, next) {
 };
 
 
-exports.register.attributes = require('../package');
+exports.register.attributes = {
+    pkg: require('../package')
+};


### PR DESCRIPTION
This just solves #6 and reflect the conventions used in the [hapi plugins documentation](http://hapijs.com/tutorials/plugins).
