### PR TITLE
feat(lib-transformer): specify event type inside of chunk of streamed…

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -32,8 +32,8 @@ internals.Transformer.prototype._transform = function (chunk, encoding, callback
         data: chunk
     };
 
-    if (this.event) {
-        event.event = this.event;
+    if (chunk.event || this.event) {
+        event.event = chunk.event || this.event;
     }
 
     this.push(Utils.stringifyEvent(event));


### PR DESCRIPTION
Allows sending a stream of events of different types through a single channel. 
How to use:

On server side
```
    stream.write({ event: 'SPECIFIC_EVENT', 'some data' }); 
    stream.write({ event: 'OTHER_EVENT', 'some data' }); 
    reply(stream);
```
On client side
```
eventSource.addEventListener('SPECIFIC_EVENT', (e) => {
                const results = JSON.parse(e.data);
                this.hosts = results;
            }, false);
eventSource.addEventListener('OTHER_EVENT', (e) => {
                const results = JSON.parse(e.data);
                this.hosts = results;
            }, false);
```